### PR TITLE
refactor(manager): use "dataset" to replace "access_info"

### DIFF
--- a/graviti/manager/commit.py
+++ b/graviti/manager/commit.py
@@ -14,7 +14,7 @@ from graviti.openapi import get_revision, list_commits
 from graviti.utility import ReprMixin
 
 if TYPE_CHECKING:
-    from graviti.manager.dataset import DatasetAccessInfo
+    from graviti.manager.dataset import Dataset
 
 ROOT_COMMIT_ID = "00000000000000000000000000000000"
 
@@ -189,23 +189,24 @@ class CommitManager:
     """This class defines the operations on the commit in Graviti.
 
     Arguments:
-        access_info: :class:`~graviti.manager.dataset.DatasetAccessInfo` instance.
-        commit_id: The commit id.
+        dataset: :class:`~graviti.manager.dataset.Dataset` instance.
 
     """
 
-    def __init__(self, access_info: "DatasetAccessInfo", commit_id: str) -> None:
-        self._access_info = access_info
-        self._commit_id = commit_id
+    def __init__(self, dataset: "Dataset") -> None:
+        self._dataset = dataset
 
     def _generate(
         self, revision: Optional[str], offset: int = 0, limit: int = 128
     ) -> Generator[Commit, None, int]:
         if revision is None:
-            revision = self._commit_id
+            revision = self._dataset.commit_id
 
         response = list_commits(
-            **self._access_info,
+            self._dataset.access_key,
+            self._dataset.url,
+            self._dataset.owner,
+            self._dataset.name,
             revision=revision,
             offset=offset,
             limit=limit,
@@ -228,9 +229,15 @@ class CommitManager:
 
         """
         if revision is None:
-            revision = self._commit_id
+            revision = self._dataset.commit_id
 
-        response = get_revision(**self._access_info, revision=revision)
+        response = get_revision(
+            self._dataset.access_key,
+            self._dataset.url,
+            self._dataset.owner,
+            self._dataset.name,
+            revision=revision,
+        )
         return Commit.from_pyobj(response)
 
     def list(self, revision: Optional[str] = None) -> PagingList[Commit]:

--- a/graviti/manager/dataset.py
+++ b/graviti/manager/dataset.py
@@ -26,43 +26,6 @@ from graviti.utility import LazyFactory, LazyList, NestedDict, ReprMixin, ReprTy
 LazyLists = NestedDict[str, LazyList[Any]]
 
 
-class DatasetAccessInfo(Mapping[str, str], ReprMixin):
-    """This class defines the basic structure of the dataset access info.
-
-    Arguments:
-        access_key: User's access key.
-        url: The URL of the graviti website.
-        owner: The owner of the dataset.
-        dataset: The name of the dataset, unique for a user.
-
-    """
-
-    _repr_attrs: Tuple[str, ...] = (
-        "access_key",
-        "url",
-        "owner",
-        "dataset",
-    )
-
-    def __init__(self, access_key: str, url: str, owner: str, dataset: str) -> None:
-        self.access_key = access_key
-        self.url = url
-        self.owner = owner
-        self.dataset = dataset
-
-    def __len__(self) -> int:
-        return len(self._repr_attrs)
-
-    def __getitem__(self, key: str) -> str:
-        try:
-            return getattr(self, key)  # type: ignore[no-any-return]
-        except AttributeError:
-            raise KeyError(key) from None
-
-    def __iter__(self) -> Iterator[str]:
-        yield from self._repr_attrs
-
-
 class Dataset(  # pylint: disable=too-many-instance-attributes
     Mapping[str, DataFrame], AttrsMixin, ReprMixin
 ):
@@ -100,11 +63,15 @@ class Dataset(  # pylint: disable=too-many-instance-attributes
 
     _dataset_id: str = attr(key="id")
 
+    access_key: str = attr()
+    url: str = attr()
+    name: str = attr()
     alias: str = attr()
     default_branch: str = attr()
     commit_id: str = attr()
     created_at: str = attr()
     updated_at: str = attr()
+    owner: str = attr()
     is_public: bool = attr()
     config: str = attr()
 
@@ -126,16 +93,19 @@ class Dataset(  # pylint: disable=too-many-instance-attributes
         is_public: bool,
         config: str,
     ) -> None:
+        self.access_key = access_key
+        self.url = url
         self._dataset_id = dataset_id
+        self.name = name
         self.alias = alias
         self.default_branch = default_branch
         self.commit_id = commit_id
         self.created_at = created_at
         self.updated_at = updated_at
+        self.owner = owner
         self.is_public = is_public
         self.config = config
         self.branch: Optional[str] = default_branch
-        self._access_info = DatasetAccessInfo(access_key, url, owner, name)
 
     def __len__(self) -> int:
         return self._get_data().__len__()
@@ -264,50 +234,7 @@ class Dataset(  # pylint: disable=too-many-instance-attributes
         """
         dataset = common_loads(cls, contents)
         dataset.branch = dataset.default_branch
-        dataset._access_info = DatasetAccessInfo(
-            contents["access_key"], contents["url"], contents["owner"], contents["name"]
-        )
         return dataset
-
-    @property
-    def access_key(self) -> str:
-        """Return the access key of the user.
-
-        Returns:
-            The access key of the user.
-
-        """
-        return self._access_info.access_key
-
-    @property
-    def url(self) -> str:
-        """Return the url of the graviti website.
-
-        Returns:
-            The url of the graviti website.
-
-        """
-        return self._access_info.url
-
-    @property
-    def owner(self) -> str:
-        """Return the owner of the dataset.
-
-        Returns:
-            The owner of the dataset.
-
-        """
-        return self._access_info.owner
-
-    @property
-    def name(self) -> str:
-        """Return the name of the dataset.
-
-        Returns:
-            The name of the dataset.
-
-        """
-        return self._access_info.dataset
 
     @property
     def branches(self) -> BranchManager:
@@ -317,7 +244,7 @@ class Dataset(  # pylint: disable=too-many-instance-attributes
             Required :class:`~graviti.manager.branch.BranchManager` instance.
 
         """
-        return BranchManager(self._access_info, self.commit_id)
+        return BranchManager(self)
 
     @property
     def drafts(self) -> DraftManager:
@@ -336,7 +263,7 @@ class Dataset(  # pylint: disable=too-many-instance-attributes
             Required :class:`~graviti.manager.commit.CommitManager` instance.
 
         """
-        return CommitManager(self._access_info, self.commit_id)
+        return CommitManager(self)
 
     @property
     def tags(self) -> TagManager:
@@ -346,7 +273,7 @@ class Dataset(  # pylint: disable=too-many-instance-attributes
             Required :class:`~graviti.manager.tag.TagManager` instance.
 
         """
-        return TagManager(self._access_info, self.commit_id)
+        return TagManager(self)
 
     def checkout(self, revision: str) -> None:
         """Checkout to a commit.


### PR DESCRIPTION
If user save the variable manager like `commit_manager = dataset.commits`,
so when the dataset checkout to other commit, the commit_id in commit_manager
will not change. This will cause some problems.