### PR TITLE
refactor: move register related classes into "portex/register.py"

### DIFF
--- a/graviti/dataframe/column/series.py
+++ b/graviti/dataframe/column/series.py
@@ -13,14 +13,14 @@ import pyarrow as pa
 
 import graviti.portex as pt
 from graviti.dataframe.column.indexing import ColumnSeriesILocIndexer, ColumnSeriesLocIndexer
-from graviti.dataframe.container import Container, ContainerRegister
+from graviti.dataframe.container import Container
 from graviti.utility import MAX_REPR_ROWS
 from graviti.utility.paging import PagingList
 
 _T = TypeVar("_T", bound="Series")
 
 
-@ContainerRegister(
+@pt.ContainerRegister(
     pt.array,
     pt.binary,
     pt.boolean,

--- a/graviti/dataframe/container.py
+++ b/graviti/dataframe/container.py
@@ -9,7 +9,7 @@ from typing import Any, List, Type, TypeVar
 
 import pyarrow as pa
 
-from graviti.portex import EXTERNAL_TYPE_TO_CONTAINER, PortexType, packages
+from graviti.portex import PortexType
 
 _T = TypeVar("_T", bound="Container")
 
@@ -59,68 +59,3 @@ class Container:
 
         """
         raise NotImplementedError
-
-
-class ContainerRegister:
-    """The class decorator to connect portex type and the data container.
-
-    Arguments:
-        portex_types: The portex types needs to be connected.
-
-    """
-
-    def __init__(self, *portex_types: Type[PortexType]) -> None:
-        self._portex_types = portex_types
-
-    def __call__(self, container: Type[_T]) -> Type[_T]:
-        """Connect data container with the portex types.
-
-        Arguments:
-            container: The data container needs to be connected.
-
-        Returns:
-            The input container class unchanged.
-
-        """
-        for portex_type in self._portex_types:
-            portex_type.container = container
-
-        return container
-
-
-class ExternalContainerRegister:
-    """The class decorator to connect portex external type and the data container.
-
-    Arguments:
-        url: The git repo url of the external package.
-        revision: The git repo revision (tag/commit) of the external package.
-        name: The portex external type name.
-
-    """
-
-    def __init__(self, url: str, revision: str, name: str) -> None:
-        self._url = url
-        self._revision = revision
-        self._name = name
-
-    def __call__(self, container: Type[_T]) -> Type[_T]:
-        """Connect data container with the portex external types.
-
-        Arguments:
-            container: The data container needs to be connected.
-
-        Returns:
-            The input container class unchanged.
-
-        """
-        EXTERNAL_TYPE_TO_CONTAINER[self._url, self._revision, self._name] = container
-
-        try:
-            package = packages.externals[self._url, self._revision]
-            class_ = package[self._name]
-        except KeyError:
-            pass
-        else:
-            class_.container = container
-
-        return container

--- a/graviti/dataframe/frame.py
+++ b/graviti/dataframe/frame.py
@@ -26,7 +26,7 @@ import pyarrow as pa
 
 import graviti.portex as pt
 from graviti.dataframe.column.series import Series as ColumnSeries
-from graviti.dataframe.container import Container, ContainerRegister
+from graviti.dataframe.container import Container
 from graviti.dataframe.indexing import DataFrameILocIndexer, DataFrameLocIndexer
 from graviti.dataframe.row.series import Series as RowSeries
 from graviti.utility import MAX_REPR_ROWS
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 _T = TypeVar("_T", bound="DataFrame")
 
 
-@ContainerRegister(pt.record)
+@pt.ContainerRegister(pt.record)
 class DataFrame(Container):
     """Two-dimensional, size-mutable, potentially heterogeneous tabular data.
 

--- a/graviti/portex/__init__.py
+++ b/graviti/portex/__init__.py
@@ -21,10 +21,12 @@ from graviti.portex.builtin import (
 from graviti.portex.catalog_to_schema import catalog_to_schema
 from graviti.portex.extractors import Extractors, get_extractors
 from graviti.portex.package import packages
-from graviti.portex.template import EXTERNAL_TYPE_TO_CONTAINER, PortexExternalType
+from graviti.portex.register import ContainerRegister, ExternalContainerRegister
+from graviti.portex.template import PortexExternalType
 
 __all__ = [
-    "EXTERNAL_TYPE_TO_CONTAINER",
+    "ContainerRegister",
+    "ExternalContainerRegister",
     "Extractors",
     "PortexExternalType",
     "PortexType",

--- a/graviti/portex/base.py
+++ b/graviti/portex/base.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 import yaml
 
 from graviti.portex.package import Imports, Package
+from graviti.portex.register import PyArrowConversionRegister
 
 if TYPE_CHECKING:
     from graviti.dataframe import Container
@@ -19,35 +20,9 @@ if TYPE_CHECKING:
 
 _INDENT = " " * 2
 
+PYARROW_TYPE_ID_TO_PORTEX_TYPE = PyArrowConversionRegister.PYARROW_TYPE_ID_TO_PORTEX_TYPE
+
 _T = TypeVar("_T", bound="PortexType")
-
-PYARROW_TYPE_ID_TO_PORTEX_TYPE = {}
-
-
-class PyArrowConversionRegister:
-    """Register the Portex type to set the conversion from PyArrow to Portex.
-
-    Arguments:
-        pyarrow_type_ids: The id of the corresponding PyArrow types.
-
-    """
-
-    def __init__(self, *pyarrow_type_ids: int) -> None:
-        self._pyarrow_type_ids = pyarrow_type_ids
-
-    def __call__(self, portex_type: Type[_T]) -> Type[_T]:
-        """Register the Portex type and return it back.
-
-        Arguments:
-            portex_type: The Portex type to register.
-
-        Returns:
-            The original Portex type.
-
-        """
-        for pyarrow_type_id in self._pyarrow_type_ids:
-            PYARROW_TYPE_ID_TO_PORTEX_TYPE[pyarrow_type_id] = portex_type
-        return portex_type
 
 
 class PortexType:
@@ -65,7 +40,7 @@ class PortexType:
         return self._repr1(0)
 
     @classmethod
-    def _from_pyarrow(cls: Type[_T], pyarrow_type: pa.DataType) -> _T:
+    def _from_pyarrow(cls, pyarrow_type: pa.DataType) -> "PortexType":
         raise NotImplementedError
 
     def _repr1(self, level: int) -> str:
@@ -157,7 +132,7 @@ class PortexType:
         return type_
 
     @classmethod
-    def from_pyarrow(cls: Type[_T], pyarrow_type: pa.DataType) -> _T:
+    def from_pyarrow(cls, pyarrow_type: pa.DataType) -> "PortexType":
         """Create Portex type instance from PyArrow type.
 
         Arguments:

--- a/graviti/portex/builtin.py
+++ b/graviti/portex/builtin.py
@@ -12,10 +12,11 @@ from typing import Any, Iterable, List, Mapping, Optional, Tuple, Type, TypeVar,
 import pyarrow as pa
 
 import graviti.portex.ptype as PTYPE
-from graviti.portex.base import PortexType, PyArrowConversionRegister
+from graviti.portex.base import PortexType
 from graviti.portex.field import Fields
 from graviti.portex.package import packages
 from graviti.portex.param import Param, Params, param
+from graviti.portex.register import PyArrowConversionRegister
 
 builtins = packages.builtins
 

--- a/graviti/portex/register.py
+++ b/graviti/portex/register.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 Graviti. Licensed under MIT License.
+#
+"""The portex type register related classes."""
+
+
+from typing import TYPE_CHECKING, ClassVar, Dict, Tuple, Type, TypeVar
+
+from graviti.portex.package import packages
+
+if TYPE_CHECKING:
+    from graviti.dataframe import Container
+    from graviti.portex.base import PortexType
+
+_P = TypeVar("_P", bound="PortexType")
+_C = TypeVar("_C", bound="Container")
+
+
+class ContainerRegister:
+    """The class decorator to connect portex type and the data container.
+
+    Arguments:
+        portex_types: The portex types needs to be connected.
+
+    """
+
+    def __init__(self, *portex_types: Type["PortexType"]) -> None:
+        self._portex_types = portex_types
+
+    def __call__(self, container: Type[_C]) -> Type[_C]:
+        """Connect data container with the portex types.
+
+        Arguments:
+            container: The data container needs to be connected.
+
+        Returns:
+            The input container class unchanged.
+
+        """
+        for portex_type in self._portex_types:
+            portex_type.container = container
+
+        return container
+
+
+class ExternalContainerRegister:
+    """The class decorator to connect portex external type and the data container.
+
+    Arguments:
+        url: The git repo url of the external package.
+        revision: The git repo revision (tag/commit) of the external package.
+        name: The portex external type name.
+
+    """
+
+    EXTERNAL_TYPE_TO_CONTAINER: ClassVar[Dict[Tuple[str, str, str], Type["Container"]]] = {}
+
+    def __init__(self, url: str, revision: str, name: str) -> None:
+        self._url = url
+        self._revision = revision
+        self._name = name
+
+    def __call__(self, container: Type[_C]) -> Type[_C]:
+        """Connect data container with the portex external types.
+
+        Arguments:
+            container: The data container needs to be connected.
+
+        Returns:
+            The input container class unchanged.
+
+        """
+        self.EXTERNAL_TYPE_TO_CONTAINER[self._url, self._revision, self._name] = container
+
+        try:
+            package = packages.externals[self._url, self._revision]
+            class_ = package[self._name]
+        except KeyError:
+            pass
+        else:
+            class_.container = container
+
+        return container
+
+
+class PyArrowConversionRegister:
+    """Register the Portex type to set the conversion from PyArrow to Portex.
+
+    Arguments:
+        pyarrow_type_ids: The id of the corresponding PyArrow types.
+
+    """
+
+    PYARROW_TYPE_ID_TO_PORTEX_TYPE: ClassVar[Dict[int, Type["PortexType"]]] = {}
+
+    def __init__(self, *pyarrow_type_ids: int) -> None:
+        self._pyarrow_type_ids = pyarrow_type_ids
+
+    def __call__(self, portex_type: Type[_P]) -> Type[_P]:
+        """Register the Portex type and return it back.
+
+        Arguments:
+            portex_type: The Portex type to register.
+
+        Returns:
+            The original Portex type.
+
+        """
+        mapping = self.PYARROW_TYPE_ID_TO_PORTEX_TYPE
+        for pyarrow_type_id in self._pyarrow_type_ids:
+            mapping[pyarrow_type_id] = portex_type
+
+        return portex_type

--- a/graviti/portex/template.py
+++ b/graviti/portex/template.py
@@ -5,7 +5,7 @@
 """Template base class."""
 
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Set, Tuple, Type
+from typing import Any, ClassVar, Dict, List, Set, Tuple, Type
 
 import pyarrow as pa
 
@@ -15,11 +15,9 @@ from graviti.portex.builtin import PortexBuiltinType
 from graviti.portex.factory import Dynamic, Factory, type_factory_creator
 from graviti.portex.package import ExternalPackage, Imports, Package, packages
 from graviti.portex.param import Param, Params
+from graviti.portex.register import ExternalContainerRegister
 
-if TYPE_CHECKING:
-    from graviti.dataframe import Container
-
-EXTERNAL_TYPE_TO_CONTAINER: Dict[Tuple[str, str, str], Type["Container"]] = {}
+EXTERNAL_TYPE_TO_CONTAINER = ExternalContainerRegister.EXTERNAL_TYPE_TO_CONTAINER
 
 
 class PortexExternalType(PortexType):  # pylint: disable=abstract-method


### PR DESCRIPTION
The following classes are moved:
- `dataframe.container.ContainerRegister`
- `dataframe.container.ExternalContainerRegister`
- `portex.base.PyArrowConversionRegister`