### PR TITLE
feat(openapi): use "__record_key" to locate data during transmission

### DIFF
--- a/graviti/openapi/data.py
+++ b/graviti/openapi/data.py
@@ -54,10 +54,10 @@ def list_draft_data(
         draft_number: The draft number.
         sheet: The sheet name.
         columns: The string of column names separated by ``|``.
-            Multiple indexes can be expressed using dots. None means to get all columns.
-        order_by: The string determine the order of sorting by the order in which column
-            names appear. If None or incomplete, the remainder is sorted by the primary key
-            of the sheet.
+            Multiple indexes can be expressed using ``.``. None means to get all columns.
+        order_by: The string of column names separated by ``|`` whose order determines the
+            precedence of the sort. The rest are sorted by `__record_key` first. Multiple
+            indexes can be expressed using ``.``.
         offset: The offset of the page.
         limit: The limit of the page.
 
@@ -72,10 +72,12 @@ def list_draft_data(
         ...     "MNIST",
         ...     draft_number = 1,
         ...     sheet = "train",
+        ...     order_by = "filename|attribute.weather",
         ... )
         {
             "data": [
                 {
+                    "__record_key": "123750493121329585",
                     "filename": "0000f77c-6257be58.jpg",
                     "image": {
                         "url": "https://content-store-prod-vers",
@@ -120,6 +122,7 @@ def list_draft_data(
             "record_size": 128,
             "total_count": 70000
         }
+
     """
     url = urljoin(url, f"v2/datasets/{owner}/{dataset}/drafts/{draft_number}/sheets/{sheet}/data")
 
@@ -152,10 +155,10 @@ def list_commit_data(
         commit_id: The commit id.
         sheet: The sheet name.
         columns: The string of column names separated by ``|``.
-            Multiple indexes can be expressed using dots. None means to get all columns.
-        order_by: The string determine the order of sorting by the order in which column
-            names appear. If None or incomplete, the remainder is sorted by the primary key
-            of the sheet.
+            Multiple indexes can be expressed using ``.``. None means to get all columns.
+        order_by: The string of column names separated by ``|`` whose order determines the
+            precedence of the sort. The rest are sorted by `__record_key` first. Multiple
+            indexes can be expressed using ``.``.
         offset: The offset of the page.
         limit: The limit of the page.
 
@@ -170,7 +173,56 @@ def list_commit_data(
         ...     "MNIST",
         ...     commit_id = "fde63f357daf46088639e9f57fd81cad",
         ...     sheet = "train",
+        ...     order_by = "filename|attribute.weather",
         ... )
+        {
+            "data": [
+                {
+                    "__record_key": "123750493121329585",
+                    "filename": "0000f77c-6257be58.jpg",
+                    "image": {
+                        "url": "https://content-store-prod-vers",
+                        "checksum": "dcc197970e607f7576d978972f6fb312911ce005"
+                    },
+                    "attribute": {
+                        "weather": "clear",
+                        "scene": "city street",
+                        "timeofday": "daytime"
+                    },
+                    "box2ds": [
+                        {
+                            "xmin": 1125.902264,
+                            "xmax": 1156.978645,
+                            "ymin": 133.184488,
+                            "ymax": 210.875445,
+                            "category": "traffic light",
+                            "attribute": {
+                                "occluded": false,
+                                "truncated": false,
+                                "trafficLightColor": "G"
+                            }
+                        },
+                        {
+                            "xmin": 1156.978645,
+                            "xmax": 1191.50796,
+                            "ymin": 136.637417,
+                            "ymax": 210.875443,
+                            "category": "traffic light",
+                            "attribute": {
+                                "occluded": false,
+                                "truncated": false,
+                                "trafficLightColor": "G"
+                            }
+                        },
+                ...
+                    ]
+                },
+                ...(total 128 items)
+            ],
+            "offset": 0,
+            "record_size": 128,
+            "total_count": 70000
+        }
 
     """
     url = urljoin(url, f"v2/datasets/{owner}/{dataset}/commits/{commit_id}/sheets/{sheet}/data")
@@ -189,8 +241,6 @@ def update_data(
     draft_number: int,
     sheet: str,
     data: List[Dict[str, Any]],
-    offset: int = 0,
-    order_by: Optional[str] = None,
 ) -> None:
     """Execute the OpenAPI `PATCH /v2/datasets/{owner}/{dataset}/drafts/{draft_number}\
     /sheets/{sheet}/data`.
@@ -203,10 +253,6 @@ def update_data(
         draft_number: The draft number.
         sheet: The sheet name.
         data: The update data.
-        offset: The starting position of the update data.
-        order_by: The string determine the order of sorting by the order in which column names
-            appear. Column names are seperated by ``|``. Multiple indexes can be expressed using
-            dots. If None or incomplete, the remainder is sorted by the primary key of the sheet.
 
     Examples:
         >>> update_dataset(
@@ -218,6 +264,7 @@ def update_data(
         ...     sheet = "train",
         ...     data = [
         ...         {
+        ...             "__record_key": "123750493121329585",
         ...             "filename": "0000f77c-6257be58.jpg",
         ...             "image": {
         ...                 "checksum": "dcc197970e607f7576d978972f6fb312911ce005"
@@ -229,6 +276,7 @@ def update_data(
         ...             },
         ...         },
         ...         {
+        ...             "__record_key": "123750493121329585",
         ...             "filename": "0000f77c-62c2a288.jpg",
         ...             "image": {
         ...                 "checksum": "dcc197970e607f7576d978972f6fb2a2881ce004"
@@ -240,15 +288,11 @@ def update_data(
         ...             },
         ...         }
         ...     ],
-        ...     offset = 10,
-        ...     order_by = "filename|attribute.weather",
         ... )
 
     """
     url = urljoin(url, f"v2/datasets/{owner}/{dataset}/drafts/{draft_number}/sheets/{sheet}/data")
-    patch_data: Dict[str, Any] = {"data": data, "offset": offset}
-    if order_by is not None:
-        patch_data["order_by"] = order_by
+    patch_data = {"data": data}
 
     open_api_do("PATCH", access_key, url, json=patch_data)
 
@@ -262,7 +306,7 @@ def add_data(
     draft_number: int,
     sheet: str,
     data: List[Dict[str, Any]],
-    strategy_argument: Optional[Dict[str, Any]] = None,
+    strategy_arguments: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Execute the OpenAPI `POST /v2/datasets/{owner}/{dataset}/drafts/{draft_number}\
     /sheets/{sheet}/data`.
@@ -275,8 +319,8 @@ def add_data(
         draft_number: The draft number.
         sheet: The sheet name.
         data: The update data.
-        strategy_argument: The dict about the argument of the Primary
-            key generation strategy of the sheet.
+        strategy_arguments: Arguments required by the ``__record_key`` generation strategy
+            of the sheet.
 
     Examples:
         >>> update_dataset(
@@ -315,8 +359,8 @@ def add_data(
     """
     url = urljoin(url, f"v2/datasets/{owner}/{dataset}/drafts/{draft_number}/sheets/{sheet}/data")
     post_data: Dict[str, Any] = {"data": data}
-    if strategy_argument is not None:
-        post_data["strategy_argument"] = strategy_argument
+    if strategy_arguments is not None:
+        post_data["strategy_arguments"] = strategy_arguments
 
     open_api_do("POST", access_key, url, json=post_data)
 

--- a/graviti/openapi/sheet.py
+++ b/graviti/openapi/sheet.py
@@ -45,7 +45,7 @@ def create_sheet(
     schema: str,
     _avro_schema: str,
     _arrow_schema: Optional[str] = None,
-    primary_key_strategy: Optional[str] = None,
+    record_key_strategy: Optional[str] = None,
 ) -> None:
     """Execute the OpenAPI `POST /v2/datasets/{owner}/{dataset}/drafts/{draft_number}/sheets`.
 
@@ -58,8 +58,8 @@ def create_sheet(
         name: The sheet name.
         schema: The portex schema of the sheet..
         _arrow_schema: The arrow schema of the sheet.
-        primary_key_strategy: The primary key generation strategy.
-            If None, it is batch auto-increment sorting primary key.
+        record_key_strategy: The ``__record_key`` generation strategy.
+            If None, it is batch auto-increment sorting record key.
 
     Examples:
         >>> create_sheet(
@@ -82,8 +82,8 @@ main", "types": [{"name": "file.Image"}]}], "type": "record", "fields": [{"name"
     url = urljoin(url, f"v2/datasets/{owner}/{dataset}/drafts/{draft_number}/sheets")
     post_data = {"name": name, "schema": schema, "_arrow_schema": _arrow_schema}
 
-    if primary_key_strategy is not None:
-        post_data["primary_key_strategy"] = primary_key_strategy
+    if record_key_strategy is not None:
+        post_data["record_key_strategy"] = record_key_strategy
 
     open_api_do("POST", access_key, url, json=post_data)
 


### PR DESCRIPTION
- Reduce the possibility of conflicts when multiple users modify the data
- It will be more convenient to expand the interface later