### PR TITLE
fix(utility): fix the ValueError in to_pyarrow when PagingList is empty

### DIFF
--- a/graviti/utility/paging.py
+++ b/graviti/utility/paging.py
@@ -607,7 +607,7 @@ class PagingList:
             The pyarrow ChunkedArray.
 
         """
-        return pa.chunked_array(page.get_array() for page in self._pages)
+        return pa.chunked_array((page.get_array() for page in self._pages), self._patype)
 
 
 PagingLists = NestedDict[str, PagingList]


### PR DESCRIPTION
```
ValueError: When passing an empty collection of arrays you must also
pass the data type
```