### PR TITLE
fix(portex): fix the "KeyError" when building external package

### DIFF
--- a/graviti/portex/package.py
+++ b/graviti/portex/package.py
@@ -271,7 +271,7 @@ class Imports(Mapping[str, Type["PortexType"]], ReprMixin):
             except KeyError:
                 continue
 
-        if self._package:
+        if self._package is not None:
             return self._package[key]
 
         raise KeyError(key)


### PR DESCRIPTION
The building order depends on the result of "Path.glob" method.
And the return order of "Path.glob" differs in different systems.

When the first building type depends on other unbuilt type, building
system will search that dependency type in the base package of the
"Imports" instance. But that time there are no types successfully
builded, the base package is an empty mapping. Which means the
search code "return self._package[key]" under the "if self._package:"
statement will be skipped and "KeyError" will be raised instead.