### PR TITLE
fix(openapi): adapt to error response without "code" in content

### DIFF
--- a/graviti/openapi/requests.py
+++ b/graviti/openapi/requests.py
@@ -57,5 +57,6 @@ def open_api_do(method: str, access_key: str, url: str, **kwargs: Any) -> Respon
         return do(method=method, url=url, **kwargs)
     except ResponseError as error:
         response = error.response
-        error_code = response.json()["code"]
-        raise RESPONSE_ERROR_DISTRIBUTOR.get(error_code, ResponseError)(response=response) from None
+        raise RESPONSE_ERROR_DISTRIBUTOR.get(
+            (response.status_code, response.json().get("code")), ResponseError
+        )(response=response) from None


### PR DESCRIPTION
When requesting to openAPI, there may be exceptions during transmission,
which leads to error response without "code" in content.