### PR TITLE
perf(portex): cache "Signature" for "PortexExternalType"

### DIFF
--- a/graviti/portex/template.py
+++ b/graviti/portex/template.py
@@ -5,6 +5,7 @@
 """Template base class."""
 
 
+from inspect import Signature
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type
 
 import pyarrow as pa
@@ -23,11 +24,16 @@ EXTERNAL_TYPE_TO_CONTAINER = ExternalContainerRegister.EXTERNAL_TYPE_TO_CONTAINE
 class PortexExternalType(PortexType):  # pylint: disable=abstract-method
     """The base class of Portex external type."""
 
+    _signature: ClassVar[Signature]
+
     package: ClassVar[ExternalPackage]
     factory: ClassVar[Factory]
 
+    def __init_subclass__(cls) -> None:
+        cls._signature = cls.params.get_signature()
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        bound_arguments = self.params.get_signature().bind(*args, **kwargs)
+        bound_arguments = self._signature.bind(*args, **kwargs)
         bound_arguments.apply_defaults()
         arguments = bound_arguments.arguments
 


### PR DESCRIPTION
| cases                  | before              | after              |
| ---------------------- | ------------------- | ------------------ |
| ob.label.Box2D()       | 153 µs ± 7.57 µs    | 122 µs ± 1.41 µs   |
| ob.label.Box3D()       | 273 µs ± 3.3 µs     | 246 µs ± 3.32 µs   |