### PR TITLE
perf(portex): use "getattr" to replace "hasattr" in "PortexType.imports"

### DIFF
--- a/graviti/portex/base.py
+++ b/graviti/portex/base.py
@@ -87,8 +87,9 @@ class PortexType:
 
         for name in self.params:
             argument = getattr(self, name)
-            if hasattr(argument, "imports"):
-                imports.update(argument.imports)
+            argument_imports = getattr(argument, "imports", None)
+            if argument_imports:
+                imports.update(argument_imports)
 
         return imports
 


### PR DESCRIPTION
| cases           | before           | after            |
| --------------- | ---------------- | ---------------- |
| bdd100k.imports | 787 µs ± 9.05 µs | 249 µs ± 4.39 µs |