### PR TITLE
feat(dataframe): add temporary support for instance and semantic mask

### DIFF
--- a/graviti/dataframe/column/series.py
+++ b/graviti/dataframe/column/series.py
@@ -365,6 +365,8 @@ class ArraySeries(Series):  # pylint: disable=abstract-method
     "file.PointCloud",
     "file.PointCloudBin",
     "file.RemoteFile",
+    "label.file.RemoteInstanceMask",
+    "label.file.RemoteSemanticMask",
 )
 class FileSeries(Series):  # pylint: disable=abstract-method
     """One-dimensional array for file."""


### PR DESCRIPTION
Add support for "label.file.RemoteInstanceMask" and
"label.file.RemoteInstanceMask" in Project-OpenBytes/standard.