### PR TITLE
refactor: separate "_init_dataframe" from "_init_data" in class "Sheets"

### DIFF
--- a/graviti/dataframe/frame.py
+++ b/graviti/dataframe/frame.py
@@ -222,7 +222,6 @@ class DataFrame(Container):
         obj.schema = schema
         obj._columns = {}
         obj._column_names = []
-        obj.operations = []
 
         # In this case schema.to_builtin always returns record.
         for key, value in schema.to_builtin().fields.items():  # type: ignore[attr-defined]

--- a/graviti/manager/draft.py
+++ b/graviti/manager/draft.py
@@ -134,6 +134,11 @@ class Draft(Sheets):  # pylint: disable=too-many-instance-attributes
             with_record_count=True,
         )
 
+    def _init_dataframe(self, sheet_name: str) -> DataFrame:
+        dataframe = super()._init_dataframe(sheet_name)
+        dataframe.operations = []
+        return dataframe
+
     def edit(self, title: Optional[str] = None, description: Optional[str] = None) -> None:
         """Update title and description of the draft.
 


### PR DESCRIPTION
At the same time, the initialization of "DataFrame.operations" has been moved
from "_from_factory" to "Draft._init_dataframe".