### PR TITLE
fix(portex): fix the incorrect "abc" module of PortexRecordBase subclass

### DIFF
--- a/graviti/portex/builder.py
+++ b/graviti/portex/builder.py
@@ -243,6 +243,7 @@ class TypeBuilder:
         params.add(Param("nullable", False, ptype=PTYPE.Boolean))
 
         class_attrs: Dict[str, Any] = {
+            "__module__": __name__,
             "params": params,
             "factory": factory,
             "package": self._builder.package,


### PR DESCRIPTION
reference: https://stackoverflow.com/questions/49457441/subclass-module \
        -set-to-metaclass-module-when-manually-creating-new-class-wit