### PR TITLE
refactor(manager): remove the reset _data operation in "Draft.upload"

### DIFF
--- a/graviti/manager/draft.py
+++ b/graviti/manager/draft.py
@@ -287,8 +287,7 @@ class Draft(Sheets):  # pylint: disable=too-many-instance-attributes
                     sheet=sheet_name,
                     jobs=jobs,
                 )
-
-        delattr(self, "_data")
+                dataframe.operations = []
 
 
 class DraftManager:


### PR DESCRIPTION
Reset DataFrame.operations instead of Draft._data:
- reduce redundant requests like "Get Sheet", "List Data"
- ensure that the DataFrame that the user get before "upload" can still be used