### PR TITLE
perf(portex): use dict instead of **kwargs to pass args in factory

### DIFF
--- a/graviti/portex/base.py
+++ b/graviti/portex/base.py
@@ -249,7 +249,7 @@ class PortexRecordBase(
 
     @property
     def _data(self) -> "ConnectedFields":  # type: ignore[override]
-        return self._fields_factory(**{name: getattr(self, name) for name in self.params})
+        return self._fields_factory({name: getattr(self, name) for name in self.params})
 
     def insert(self, index: int, name: str, portex_type: PortexType) -> None:
         """Insert the name and portex_type at the index.

--- a/graviti/portex/external.py
+++ b/graviti/portex/external.py
@@ -61,8 +61,7 @@ class PortexExternalType(PortexType):  # pylint: disable=abstract-method
             The internal type of the PortexExternalType.
 
         """
-        arguments = {name: getattr(self, name) for name in self.params}
-        return self._factory(**arguments)
+        return self._factory({name: getattr(self, name) for name in self.params})
 
     def to_pyarrow(self) -> pa.DataType:
         """Convert the Portex type to the corresponding builtin PyArrow DataType.


### PR DESCRIPTION
Tests on box2d of VOC2012Detection.

| cases               | before           | after             |
| ---------------     | ---------------- | ----------------  |
| box2d.internal_type | 59.5 µs ± 104 ns | 54.1 µs ± 99.7 ns |
| box2d.to_builtin()  | 145 µs ± 14.5 µs | 124 µs ± 292 ns   |
| box2d._data         | 90.2 µs ± 113 ns | 80.5 µs ± 3.59 µs |