### PR TITLE
fix(manager): fix NoCommitsError caused by "BranchManager.get"

### DIFF
--- a/graviti/manager/branch.py
+++ b/graviti/manager/branch.py
@@ -134,7 +134,7 @@ class BranchManager:
             branch=name,
         )
 
-        if getattr(self._dataset, "HEAD", None):
+        if getattr(self._dataset, "HEAD", None) is not None:
             check_head_status(self._dataset.HEAD, name, response["commit_id"])
 
         return Branch(self._dataset, **response)


### PR DESCRIPTION
When we get the branch "main" on a dataset without any commit history,
this error will be raised.