### PR TITLE
fix(manager): fix NoCommitsError caused by "BranchManager.get"

### DIFF
--- a/graviti/manager/branch.py
+++ b/graviti/manager/branch.py
@@ -134,8 +134,9 @@ class BranchManager:
             branch=name,
         )
 
-        if getattr(self._dataset, "HEAD", None):
-            check_head_status(self._dataset.HEAD, name, response["commit_id"])
+        head = getattr(self._dataset, "HEAD", None)
+        if head is not None:
+            check_head_status(head, name, response["commit_id"])
 
         return Branch(self._dataset, **response)
 


### PR DESCRIPTION
When we get the branch "main" on a dataset without any commit history,
this error will be raised.