### PR TITLE
fix(portex): fix the AttributeError when "import graviti" in Python3.6

### DIFF
--- a/graviti/portex/builder.py
+++ b/graviti/portex/builder.py
@@ -15,8 +15,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, TypeVar
 
 import yaml
 
-import graviti.portex.ptype as PTYPE
 from graviti.exception import GitCommandError, GitNotFoundError
+from graviti.portex import ptype as PTYPE
 from graviti.portex.base import PortexRecordBase
 from graviti.portex.external import PortexExternalType
 from graviti.portex.factory import ConnectedFieldsFactory, TypeFactory

--- a/graviti/portex/builtin.py
+++ b/graviti/portex/builtin.py
@@ -11,7 +11,7 @@ from typing import Iterable, List, Mapping, Optional, Tuple, Type, TypeVar, Unio
 
 import pyarrow as pa
 
-import graviti.portex.ptype as PTYPE
+from graviti.portex import ptype as PTYPE
 from graviti.portex.base import PortexRecordBase, PortexType
 from graviti.portex.factory import ConnectedFieldsFactory
 from graviti.portex.field import Fields

--- a/graviti/portex/factory.py
+++ b/graviti/portex/factory.py
@@ -22,7 +22,7 @@ from typing import (
     Union,
 )
 
-import graviti.portex.ptype as PTYPE
+from graviti.portex import ptype as PTYPE
 from graviti.portex.base import PortexRecordBase, PortexType
 from graviti.portex.field import ConnectedFields, Fields, FrozenFields
 from graviti.portex.package import Imports

--- a/graviti/portex/param.py
+++ b/graviti/portex/param.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from inspect import Parameter, Signature
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
 
-import graviti.portex.ptype as PTYPE
+from graviti.portex import ptype as PTYPE
 from graviti.portex.package import Imports
 from graviti.utility import UserMapping
 


### PR DESCRIPTION
Error message:
AttributeError: module 'graviti' has no attribute 'portex'