### PR TITLE
feat(dataframe): forbid deleting items by loc for non-root Containers

### DIFF
--- a/graviti/dataframe/column/series.py
+++ b/graviti/dataframe/column/series.py
@@ -115,7 +115,12 @@ class SeriesBase(Container):  # pylint: disable=abstract-method
         return self._data[key]
 
     def __delitem__(self, key: Union[int, slice]) -> None:
-        self._data.__delitem__(key)
+        if self._root is not None:
+            raise TypeError(
+                "'__delitem__' is not supported for the Series which is a member of a DataFrame"
+            )
+
+        self._del_item_by_location(key)
 
     @overload
     def __setitem__(self, key: slice, value: Union[Iterable[Any], _SB]) -> None:
@@ -188,6 +193,9 @@ class SeriesBase(Container):  # pylint: disable=abstract-method
 
     def _get_repr_indices(self) -> Iterable[int]:
         return islice(range(len(self)), MAX_REPR_ROWS)
+
+    def _del_item_by_location(self, key: Union[int, slice]) -> None:
+        self._data.__delitem__(key)
 
     # @overload
     # @staticmethod

--- a/graviti/dataframe/container.py
+++ b/graviti/dataframe/container.py
@@ -5,7 +5,7 @@
 """The table-structured data container related classes."""
 
 
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, TypeVar, Union
 
 import pyarrow as pa
 
@@ -60,6 +60,9 @@ class Container:
         raise NotImplementedError
 
     def _to_post_data(self) -> List[Any]:
+        raise NotImplementedError
+
+    def _del_item_by_location(self, key: Union[int, slice]) -> None:
         raise NotImplementedError
 
     # TODO: Defines a base indexer for the loc and iloc return type.

--- a/graviti/dataframe/frame.py
+++ b/graviti/dataframe/frame.py
@@ -372,7 +372,7 @@ class DataFrame(Container):
 
     def _del_item_by_location(self, key: Union[int, slice]) -> None:
         for column in self._columns.values():
-            column.loc.__delitem__(key)
+            column._del_item_by_location(key)  # pylint: disable=protected-access
         if self.operations is not None:
             record_key = self._record_key
             if isinstance(key, int):

--- a/graviti/dataframe/indexing.py
+++ b/graviti/dataframe/indexing.py
@@ -105,6 +105,12 @@ class DataFrameILocIndexer:
             self.obj.operations.append(UpdateData(dataframe))
 
     def __delitem__(self, key: Union[int, slice]) -> None:
+        if self.obj._root is not None:
+            raise TypeError(
+                "'iloc.__delitem__' is not supported for the DataFrame"
+                "which is a member of another DataFrame"
+            )
+
         self.obj._del_item_by_location(key)
 
 
@@ -196,4 +202,10 @@ class DataFrameLocIndexer:
             self.obj.operations.append(UpdateData(dataframe))
 
     def __delitem__(self, key: Union[int, slice]) -> None:
+        if self.obj._root is not None:
+            raise TypeError(
+                "'loc.__delitem__' is not supported for the DataFrame"
+                "which is a member of another DataFrame"
+            )
+
         self.obj._del_item_by_location(key)


### PR DESCRIPTION
Not support '__delitem__' for the Series which is a member of a
DataFrame.

Not support 'loc.__delitem__' and 'iloc.__delitem__' for the DataFrame
which is a member of another DataFrame