### PR TITLE
feat: check field name confliction in "Sheets._upload_to_draft"

### DIFF
--- a/graviti/exception.py
+++ b/graviti/exception.py
@@ -39,6 +39,10 @@ class PortexError(GravitiException):
     """This is the base class for custom exceptions in Graviti portex module."""
 
 
+class FieldNameConflictError(PortexError):
+    """This class defines the exception for the portex field name error."""
+
+
 class GitNotFoundError(PortexError):
     """This class defines the exception for the git command not found error.
 


### PR DESCRIPTION
Field names in Graviti data platform is case insensitive, graviti
python SDK is case sensitive. These difference may cause confliction
when uploading local data to data platform.