### PR TITLE
fix(dataframe): fix Series creation fail when the array items is enum

### DIFF
--- a/graviti/dataframe/column/series.py
+++ b/graviti/dataframe/column/series.py
@@ -251,17 +251,26 @@ class SeriesBase(Container):  # pylint: disable=abstract-method
     @staticmethod
     def _process_array(
         values: Iterable[Any], schema: pt.PortexType
-    ) -> Tuple[Callable[[Any], Any], bool]:
+    ) -> Tuple[Callable[[Any], Any], Optional[bool]]:
+        if not values:
+            return lambda x: x, None
+
         for value in values:
             if value is None:
                 continue
+
             processor, need_process = SeriesBase._get_process(value, schema)
+            if need_process is None:
+                continue
+
             return lambda x: list(map(processor, x)), need_process
 
         return lambda x: x, False
 
     @staticmethod
-    def _get_process(value: Any, schema: pt.PortexType) -> Tuple[Callable[[Any], Any], bool]:
+    def _get_process(
+        value: Any, schema: pt.PortexType
+    ) -> Tuple[Callable[[Any], Any], Optional[bool]]:
         container = schema.container
         if value.__class__.__name__ == "DataFrame":
             return lambda x: x._to_post_data(), True  # pylint: disable=protected-access


### PR DESCRIPTION
example:
```python
In [10]: schema  # the array items is enum
Out[10]:
array(
  items=enum(
    values=['cat', 'dog'],
  ),
)

In [11]: data  # the first array is an empty list
Out[11]: [[], ['cat', 'dog'], ['cat', 'dog'], ['cat', 'dog']]

In [12]: Series(data, schema)  # creation fail
---------------------------------------------------------------------------
ArrowInvalid                              Traceback (most recent call last)
...
...

ArrowInvalid: Could not convert 'cat' with type str: tried to convert to int8
```