### PR TITLE
fix(openapi): fix "Extra input fields" error when uploading binary to s3

### DIFF
--- a/graviti/openapi/file.py
+++ b/graviti/openapi/file.py
@@ -172,6 +172,15 @@ def upload_file(
             post_data,
             checksum,
         )
+    elif backend_type == "s3":
+        if "signedRequestHeaders" in post_data:
+            del post_data["signedRequestHeaders"]
+
+        _post_multipart_formdata(
+            host,
+            local_path,
+            post_data,
+        )
     else:
         _post_multipart_formdata(
             host,


### PR DESCRIPTION
Error Message from S3:
"Invalid according to Policy: Extra input fields: signedrequestheaders"