### PR TITLE
refactor: apply "sort" parameter to three list openapi functions

### DIFF
--- a/graviti/manager/search.py
+++ b/graviti/manager/search.py
@@ -16,7 +16,7 @@ from graviti.openapi import (
     get_search_history,
     list_search_histories,
 )
-from graviti.utility import ReprMixin, check_type, convert_iso_to_datetime
+from graviti.utility import ReprMixin, SortParam, check_type, convert_iso_to_datetime
 
 if TYPE_CHECKING:
     from graviti.manager.dataset import Dataset
@@ -101,8 +101,7 @@ class SearchManager:
         commit_id: Optional[str],
         draft_number: Optional[int],
         sheet: Optional[str],
-        order_by: Optional[str],
-        sort: Optional[str],
+        sort: SortParam,
     ) -> Generator[SearchHistory, None, int]:
         _dataset = self._dataset
         response = list_search_histories(
@@ -113,7 +112,6 @@ class SearchManager:
             commit_id=commit_id,
             draft_number=draft_number,
             sheet=sheet,
-            order_by=order_by,
             sort=sort,
             limit=limit,
             offset=offset,
@@ -174,8 +172,7 @@ class SearchManager:
         commit_id: Optional[str],
         draft_number: Optional[int],
         sheet: Optional[str],
-        order_by: Optional[str],
-        sort: Optional[str],
+        sort: SortParam,
     ) -> LazyPagingList[SearchHistory]:
         """List Graviti search histories.
 
@@ -183,8 +180,7 @@ class SearchManager:
             commit_id: The commit id.
             draft_number: The draft number.
             sheet: The name of the sheet.
-            order_by: Return the requests ordered by which field, default is "created_at".
-            sort: Return the requests sorted in ASC or DESC order, default is DESC.
+            sort: The column and the direction the list result sorted by.
 
         Returns:
             The LazyPagingList of :class:`~graviti.manager.search.SearchHistory` instances.
@@ -197,7 +193,6 @@ class SearchManager:
                 commit_id=commit_id,
                 draft_number=draft_number,
                 sheet=sheet,
-                order_by=order_by,
                 sort=sort,
             ),
             LIMIT,

--- a/graviti/openapi/search.py
+++ b/graviti/openapi/search.py
@@ -8,6 +8,7 @@
 from typing import Any, Dict, Optional
 
 from graviti.openapi.requests import open_api_do
+from graviti.utility import SortParam
 
 
 def create_search(
@@ -216,8 +217,7 @@ def list_search_histories(
     commit_id: Optional[str] = None,
     draft_number: Optional[int] = None,
     sheet: Optional[str] = None,
-    order_by: Optional[str] = None,
-    sort: Optional[str] = None,
+    sort: SortParam = None,
     offset: Optional[int] = None,
     limit: Optional[int] = None,
 ) -> Dict[str, Any]:
@@ -231,8 +231,7 @@ def list_search_histories(
         commit_id: The commit id.
         draft_number: The draft number.
         sheet: The name of the sheet.
-        order_by: Return the requests ordered by which field, default is "created_at".
-        sort: Return the requests sorted in ASC or DESC order, default is DESC.
+        sort: The column and the direction the list result sorted by.
         offset: The offset of the page. The default value of this param in OpenAPIv2 is 0.
         limit: The limit of the page. The default value of this param in OpenAPIv2 is 128.
 
@@ -290,8 +289,6 @@ def list_search_histories(
         params["draft_number"] = draft_number
     if sheet is not None:
         params["sheet"] = sheet
-    if order_by is not None:
-        params["order_by"] = order_by
     if sort is not None:
         params["sort"] = sort
     if offset is not None:
@@ -424,6 +421,7 @@ def list_search_records(
     dataset: str,
     *,
     search_id: str,
+    sort: SortParam = None,
     offset: Optional[int] = None,
     limit: Optional[int] = None,
 ) -> Dict[str, Any]:
@@ -435,6 +433,7 @@ def list_search_records(
         workspace: The name of the workspace.
         dataset: The name of the dataset.
         search_id: The search id.
+        sort: The column and the direction the list result sorted by.
         offset: The offset of the page. The default value of this param in OpenAPIv2 is 0.
         limit: The limit of the page. The default value of this param in OpenAPIv2 is 128.
 
@@ -475,6 +474,8 @@ def list_search_records(
     url = f"{url}/v2/datasets/{workspace}/{dataset}/searches/{search_id}/records"
 
     params: Dict[str, Any] = {}
+    if sort is not None:
+        params["sort"] = sort
     if offset is not None:
         params["offset"] = offset
     if limit is not None:

--- a/graviti/openapi/storage_config.py
+++ b/graviti/openapi/storage_config.py
@@ -8,6 +8,7 @@
 from typing import Any, Dict, Optional
 
 from graviti.openapi.requests import open_api_do
+from graviti.utility import SortParam
 
 
 def list_storage_configs(
@@ -15,6 +16,7 @@ def list_storage_configs(
     url: str,
     workspace: str,
     *,
+    sort: SortParam = None,
     offset: Optional[int] = None,
     limit: Optional[int] = None,
 ) -> Dict[str, Any]:
@@ -24,6 +26,7 @@ def list_storage_configs(
         access_key: User's access key.
         url: The URL of the graviti website.
         workspace: The name of the workspace.
+        sort: The column and the direction the list result sorted by.
         offset: The offset of the page. The default value of this param in OpenAPIv2 is 0.
         limit: The limit of the page. The default value of this param in OpenAPIv2 is 128.
 
@@ -56,7 +59,9 @@ def list_storage_configs(
     """
     url = f"{url}/v2/workspaces/{workspace}/storage-configs"
 
-    params = {}
+    params: Dict[str, Any] = {}
+    if sort is not None:
+        params["sort"] = sort
     if offset is not None:
         params["offset"] = offset
     if limit is not None:

--- a/graviti/utility/__init__.py
+++ b/graviti/utility/__init__.py
@@ -25,7 +25,7 @@ from graviti.utility.engine import Mode, engine
 from graviti.utility.itertools import chunked
 from graviti.utility.repr import INDENT, MAX_REPR_ROWS, ReprMixin, ReprType
 from graviti.utility.requests import UserResponse, config, get_session, submit_multithread_tasks
-from graviti.utility.typing import NestedDict, PathLike, check_type
+from graviti.utility.typing import NestedDict, PathLike, SortParam, check_type
 
 __all__ = [
     "AttrDict",
@@ -39,6 +39,7 @@ __all__ = [
     "PathLike",
     "ReprMixin",
     "ReprType",
+    "SortParam",
     "UserMapping",
     "UserMutableMapping",
     "UserMutableSequence",

--- a/graviti/utility/typing.py
+++ b/graviti/utility/typing.py
@@ -7,7 +7,7 @@
 
 import inspect
 from pathlib import Path
-from typing import AbstractSet, Any, Tuple, Type, TypeVar, Union
+from typing import AbstractSet, Any, Iterable, Tuple, Type, TypeVar, Union
 
 from typing_extensions import Protocol
 
@@ -15,6 +15,7 @@ _K = TypeVar("_K")
 _V = TypeVar("_V")
 
 PathLike = Union[str, Path]
+SortParam = Union[str, Iterable[str], None]
 
 
 class NestedDict(Protocol[_K, _V]):


### PR DESCRIPTION
The "sort" parameter is applied to the following openapi functions:
- `list_storage_configs`
- `list_search_histories`
- `list_search_records`