### PR TITLE
ci: set ubuntu version to "20.04" for "Pre-commit"

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8.1]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
"ruby/setup-ruby@v1" does not support ubuntu-20.04 anymore